### PR TITLE
Upgrade to vouch v0.17.3

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v1
-appVersion: "0.9.5"
+appVersion: "0.17.3"
 description: An SSO and OAuth login solution for nginx using the auth_request module
 name: vouch
-version: 0.2.1
+version: 0.3.1
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4
 sources:
   - https://github.com/vouch/vouch-proxy/

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: VOUCH_PORT
+              value: {{ .Values.config.vouch.port | quote }}
           ports:
             - name: http
               containerPort: 9090

--- a/values.yaml
+++ b/values.yaml
@@ -52,12 +52,12 @@ affinity: {}
 
 config:
   vouch:
+    port: 9090
     domains: []
     allowAllUsers: false
     whiteList: []
     jwt:
       secret: super-secret-stuff
-    webapp: false
     testing: false
 
   oauth:


### PR DESCRIPTION
Hi, I forked these charts and got them working with the latest vouch proxy image on docker hub 0.17.3 and thought I'd contribute back. Changes:

* I found I needed to set VOUCH_PORT as it was getting defaulted to a hostname rather than a port and vouch was trying to parse it as an int.
* It seems vouch added some config validation and `webapp: false` conficted with other values