### PR TITLE
Update ingress apiVersion & permits to configure it as a value

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "0.17.3"
 description: An SSO and OAuth login solution for nginx using the auth_request module
 name: vouch
-version: 0.5.0
+version: 0.5.1
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4
 sources:
   - https://github.com/vouch/vouch-proxy/

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "vouch.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.NetworkPolicy.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "vouch.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-apiVersion: {{ .Values.NetworkPolicy.apiVersion }}
+apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,7 @@ service:
 
 ingress:
   enabled: false
+  apiVersion: networking.k8s.io/v1beta1
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
_The v1.22 release will stop serving the following deprecated API versions in favor of newer and more stable API versions:
    Ingress in the extensions/v1beta1 API version will no longer be served
        Migrate to use the networking.k8s.io/v1beta1 API version, available since v1.14. Existing persisted data can be retrieved/updated via the new version._
(https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)

This PR has the purpose to switch to _networking.k8s.io/v1beta1_ ingress apiVersion and to permit to define it as a value.

For info here are the apiVersion to set depending on the Kubernetes Cluster this ingress has to be created on:
```
networking.k8s.io/v1beta1 == 1.14 to 1.18
networking.k8s.io/v1 = 1.19+
```