### PR TITLE
Add image command and args in deployment template

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "0.17.3"
 description: An SSO and OAuth login solution for nginx using the auth_request module
 name: vouch
-version: 1.0.0
+version: 1.0.1
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4
 sources:
   - https://github.com/vouch/vouch-proxy/

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
+          command:
+            {{- toYaml .Values.command | nindent 12 }}
+          args:
+            {{- toYaml .Values.args | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: VOUCH_PORT

--- a/values.yaml
+++ b/values.yaml
@@ -9,6 +9,8 @@ image:
   tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent
 
+command: []
+args: []
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/values.yaml
+++ b/values.yaml
@@ -9,8 +9,11 @@ image:
   tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent
 
+# Allow to specify an alternate command before launching vouch
+# ex: command: ["/bin/sh", "-c", "source /vault/secrets/config && /vouch-proxy"]
 command: []
 args: []
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
It adds command and args in the deployment template, that way it's possible to specify a custom entrypoint (for secret injection for instance)
