### PR TITLE
it is safer if the jwt.secret is not set by default

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "0.17.3"
 description: An SSO and OAuth login solution for nginx using the auth_request module
 name: vouch
-version: 1.0.0
+version: 2.0.0
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4
 sources:
   - https://github.com/vouch/vouch-proxy/

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "0.17.3"
 description: An SSO and OAuth login solution for nginx using the auth_request module
 name: vouch
-version: 2.0.0
+version: 1.1.0
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4
 sources:
   - https://github.com/vouch/vouch-proxy/

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,4 +1,7 @@
 {{- if not .Values.existingSecretName }}
+{{- if (lt (len .Values.config.vouch.jwt.secret) 1) }}
+  {{ fail "`config.vouch.jwt.secret` is not set and we are no longer providing a weak default" }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -107,8 +107,6 @@ config:
     domains: []
     allowAllUsers: false
     whiteList: []
-    jwt:
-      secret: super-secret-stuff
     testing: false
 
   oauth:

--- a/values.yaml
+++ b/values.yaml
@@ -107,6 +107,8 @@ config:
     domains: []
     allowAllUsers: false
     whiteList: []
+    jwt:
+      secret: ''
     testing: false
 
   oauth:


### PR DESCRIPTION
This change probably warrents attention from the user, as it may
invalidate the sessions of logged in users when this change is
uptaken.

However I believe it is an acceptable interference. As things are
now, if a deployment of vouch does not set the jwt.secret then the
cookie, copied to another domain would be accepted.

With this change, the default behaviour causes vouch to generate a
secret.