### PR TITLE
Update deployments.yaml to allow multiple env-vars.

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "0.23.1"
 description: An SSO and OAuth login solution for nginx using the auth_request module
 name: vouch
-version: 2.0.0
+version: 3.0.0
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4
 sources:
   - https://github.com/vouch/vouch-proxy/

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -60,8 +60,9 @@ spec:
             {{- toYaml .Values.args | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: VOUCH_PORT
-              value: {{ .Values.config.vouch.port | quote }}
+          {{- if .Values.extraEnvs }}
+          {{ toYaml .Values.extraEnvs | nindent 10 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 9090

--- a/values.yaml
+++ b/values.yaml
@@ -106,6 +106,11 @@ deploymentAnnotations: {}
 # vouch config
 # bare minimum to get vouch running with google
 
+extraEnvs:
+  - VOUCH_PORT: 9090
+  - OAUTH_CLIENT_ID: abc123
+  - OAUTH_CLIENT_SECRET: abc123
+
 config:
   vouch:
     port: 9090


### PR DESCRIPTION
Make it possible to set multiple environment variables on deployments e.g. client-secret and client-id.

This makes it easier to populate these via SOPS and avoid clear text secret/values in values.yaml