### PR TITLE
Making containerPort track the envvar

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -64,11 +64,7 @@ spec:
               value: {{ .Values.config.vouch.port | quote }}
           ports:
             - name: http
-              {{- if .Values.config.vouch.port }}
               containerPort: {{ .Values.config.vouch.port }}
-              {{- else }}
-              containerPort: 9090
-              {{- end }}
               protocol: TCP
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -64,7 +64,11 @@ spec:
               value: {{ .Values.config.vouch.port | quote }}
           ports:
             - name: http
+              {{- if .Values.config.vouch.port }}
+              containerPort: {{ .Values.config.vouch.port }}
+              {{- else }}
               containerPort: 9090
+              {{- end }}
               protocol: TCP
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:


### PR DESCRIPTION
I needed to run this on a different port so I set `.Values.config.vouch.port`, but I noticed that the deployment's containerPort was set to 9090.  Not a big deal.  You can set both, but this PR makes the envvar for port match the containerPort.