### PR TITLE
add envFrom for env from secrets

### DIFF
--- a/charts/vouch/Chart.yaml
+++ b/charts/vouch/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 type: application
 appVersion: "0.36"
-version: 3.1.0
+version: 3.2.0
 name: vouch
 description: An SSO and OAuth login solution for nginx using the auth_request module.
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4

--- a/charts/vouch/README.md
+++ b/charts/vouch/README.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+3.2.0
+  * Add envFrom option to enable passing env vars from secrets
+
 3.1.0
   * Add extraEnvVars option to add env variables to the vouch deployment
 

--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+            {{ toYaml .Values.envFrom | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.config.vouch.port }}

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -131,3 +131,9 @@ existingSecretName: ""
 #   - name: HTTPS_PROXY
 #     value: "https://example.com"
 extraEnvVars: []
+
+# An (optional) array to pull environment variables from secrets or configmaps
+# passes directly through to standard Kubernetes envFrom.
+# envFrom:
+#   - secretRef:
+#       name: vouch-env-secret


### PR DESCRIPTION
- Adds envFrom support for values.  Personal use case is for secrets created from vault for things like OAUTH_CLIENT_SECRET, while still keeping most of the config in the helm chart.
- Bumps version to 3.2.0

Hope I'm not missing some simple way to merge the config secret and creds secret. 

Thanks!