### PR TITLE
fix: handle self-signed CA into Vouch proxy

### DIFF
--- a/charts/vouch/Chart.yaml
+++ b/charts/vouch/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 type: application
 appVersion: "0.36"
-version: 3.1.0
+version: 3.2.0
 name: vouch
 description: An SSO and OAuth login solution for nginx using the auth_request module.
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4

--- a/charts/vouch/README.md
+++ b/charts/vouch/README.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+3.2.0
+  * Add an option to set extra self-signed CA files
+
 3.1.0
   * Add extraEnvVars option to add env variables to the vouch deployment
 

--- a/charts/vouch/templates/ca-configmap.yaml
+++ b/charts/vouch/templates/ca-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.additionalCA }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "vouch.fullname" . }}-ca
+  labels:
+{{ include "vouch.labels" . | indent 4 }}
+data:
+  ca.crt: |
+{{ .Values.additionalCA | indent 4}}
+{{- end }}

--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -106,16 +106,38 @@ spec:
           volumeMounts:
           - name: data
             mountPath: /data
+          {{- if .Values.additionalCA }}
+          - name: merge-ca
+            mountPath: /etc/ssl/certs/
+          {{- end }}
           - name: config
             mountPath: /config
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.additionalCA }}
+      initContainers:
+        - name: merge-ca
+          image: alpine
+          command: [ '/bin/sh', '-c', 'cp /etc/ssl/certs/ca-certificates.crt /CA && cat /ca-map/ca.crt >> /CA/ca-certificates.crt' ]
+          volumeMounts:
+            - name: ca-configmap
+              mountPath: /ca-map
+            - name: merge-ca
+              mountPath: /CA
+      {{- end }}
       volumes:
       - name: config
         secret:
           secretName: {{ if .Values.existingSecretName }}{{ .Values.existingSecretName }}{{- else }}{{ template "vouch.fullname" . }}{{- end }}
       - name: data
         emptyDir: {}
+      {{- if .Values.additionalCA }}
+      - name: ca-configmap
+        configMap:
+          name: {{ include "vouch.fullname" . }}-ca
+      - name: merge-ca
+        emptyDir: {}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -131,3 +131,11 @@ existingSecretName: ""
 #   - name: HTTPS_PROXY
 #     value: "https://example.com"
 extraEnvVars: []
+
+# allow to add a new CA for Vouch proxy, for example when using a self-signed CA in your company
+# put your CA as a raw value
+# additionalCA: |
+#    -----BEGIN CERTIFICATE-----
+#    MIIFYDCCA0igAwIBAgIUbblUcUL4T5C[...]
+#    -----END CERTIFICATE-----
+additionalCA: ""


### PR DESCRIPTION
fixes:  https://github.com/vouch/vouch-proxy/issues/145

Allow to add internal self-signed CA  into the container 
In our company we have a internal Keycloak OIDC and we need to add our certificate.

create a new image from the official and extend is not our best option because we don't want to maintain every new version