### PR TITLE
feat: extraEnvVars to support secret values

### DIFF
--- a/charts/vouch/Chart.yaml
+++ b/charts/vouch/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 type: application
 appVersion: "0.36"
-version: 3.1.0
+version: 3.1.1
 name: vouch
 description: An SSO and OAuth login solution for nginx using the auth_request module.
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4

--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -62,9 +62,8 @@ spec:
           env:
             - name: VOUCH_PORT
               value: {{ .Values.config.vouch.port | quote }}
-            {{- range .Values.extraEnvVars }}
-            - name: {{ .name }}
-              value: {{ .value | quote }}
+            {{- if .Values.extraEnvVars }}
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -130,4 +130,10 @@ existingSecretName: ""
 # extraEnvVars:
 #   - name: HTTPS_PROXY
 #     value: "https://example.com"
+#   - name: SECRET_VALUE
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secrets
+#         key: password
+
 extraEnvVars: []


### PR DESCRIPTION
This allows importing values directly from secret.

Example:
```yaml
---
extraEnvVars:
  - name: HTTPS_PROXY
    value: "https://example.com"
  - name: SECRET_VALUE
    valueFrom:
      secretKeyRef:
        name: my-secrets
        key: password
``` 
