### PR TITLE
Update Chart.yaml - bump chart version

### DIFF
--- a/charts/vouch/Chart.yaml
+++ b/charts/vouch/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 type: application
 appVersion: "0.39"
-version: 3.1.0
+version: 3.2.0
 name: vouch
 description: An SSO and OAuth login solution for nginx using the auth_request module.
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4


### PR DESCRIPTION
This should fix [the failing deployment](https://github.com/vouch/helm-charts/actions/runs/5132555396), as it can't release the same version twice. This would be a version bump for the change, https://github.com/vouch/helm-charts/pull/34, that was merged last week.