### PR TITLE
Support overriding vouch version via image.tag

### DIFF
--- a/charts/vouch/Chart.yaml
+++ b/charts/vouch/Chart.yaml
@@ -33,4 +33,4 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: vouch-proxy
-      image: "quay.io/vouch/vouch-proxy:0.32.0"
+      image: "quay.io/vouch/vouch-proxy:0.39"

--- a/charts/vouch/Chart.yaml
+++ b/charts/vouch/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 type: application
 appVersion: "0.39"
-version: 3.2.0
+version: 3.2.1
 name: vouch
 description: An SSO and OAuth login solution for nginx using the auth_request module.
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4

--- a/charts/vouch/README.md
+++ b/charts/vouch/README.md
@@ -1,7 +1,10 @@
 ## Changelog
 
+3.2.1
+  * Version can be overridden by specifying `image.tag`
+
 3.2.0
-  * Default app version is now 0.39. Version can be overridden by specifying `image.tag`
+  * Default app version is now 0.39.
 
 3.1.0
   * Add extraEnvVars option to add env variables to the vouch deployment
@@ -11,7 +14,6 @@
 
 3.0.6
   * Allow vouch-proxy to default the secret at startup
-
 
 2.0.0
   * Require Vouch secret to be set (#8 thanks @punkle)

--- a/charts/vouch/README.md
+++ b/charts/vouch/README.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+3.2.0
+  * Default app version is now 0.39. Version can be overridden by specifying `image.tag`
+
 3.1.0
   * Add extraEnvVars option to add env variables to the vouch deployment
 

--- a/charts/vouch/templates/_helpers.tpl
+++ b/charts/vouch/templates/_helpers.tpl
@@ -37,8 +37,8 @@ Common labels
 {{- define "vouch.labels" -}}
 helm.sh/chart: {{ include "vouch.chart" . }}
 {{ include "vouch.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- if or .Chart.AppVersion .Values.image.tag }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/charts/vouch/templates/_helpers.tpl
+++ b/charts/vouch/templates/_helpers.tpl
@@ -33,12 +33,13 @@ Create chart name and version as used by the chart label.
 
 {{/*
 Common labels
+App version - handle Docker image SHAs by replacing invalid characters and truncate to Kubernetes 63 char limit.
 */}}
 {{- define "vouch.labels" -}}
 helm.sh/chart: {{ include "vouch.chart" . }}
 {{ include "vouch.selectorLabels" . }}
 {{- if or .Chart.AppVersion .Values.image.tag }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | replace "@" "." | replace "sha256:" "" | trunc 63 | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command:
             {{- toYaml .Values.command | nindent 12 }}
           args:

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -6,7 +6,8 @@ replicaCount: 1
 
 image:
   repository: quay.io/vouch/vouch-proxy
-  tag: "{{ .Chart.AppVersion }}"
+  # Overrides image tag. Default is {{ .Chart.AppVersion }}
+  tag: ""
   pullPolicy: IfNotPresent
 
 # Allow to specify an alternate command before launching vouch


### PR DESCRIPTION
Motivation: Support overriding vouch-proxy version installed by the helm chart to easily test different versions.
This change ensures that `app.kubernetes.io/version` will always show the current image tag of the deployed Vouch image.

* Image tag defaults to `appVersion` and can be overridden in values file by `image.tag`
* Bump Helm chart version to 3.2.1

Example:
```yaml
❯ helm template my-vouch charts/vouch --set image.tag=0.36 | grep -C1 36
    app.kubernetes.io/instance: my-vouch
    app.kubernetes.io/version: "0.36"
    app.kubernetes.io/managed-by: Helm
--
    app.kubernetes.io/instance: my-vouch
    app.kubernetes.io/version: "0.36"
    app.kubernetes.io/managed-by: Helm
--
    app.kubernetes.io/instance: my-vouch
    app.kubernetes.io/version: "0.36"
    app.kubernetes.io/managed-by: Helm
--
            {}
          image: "quay.io/vouch/vouch-proxy:0.36"
          command:
```

Tested with SHA-based image tag:
```yaml
❯ helm upgrade --install my-vouch charts/vouch --set image.tag=latest@sha256:d34e220de3cfb8a0615ce4554c51b4e03cc22277f28e8984c3047ae7e6a1b949
❯ kubectl describe svc my-vouch | grep -C1 version
                   app.kubernetes.io/name=vouch
                   app.kubernetes.io/version=d34e220de3cfb8a0615ce4554c51b4e03cc22277f28e8984c3047ae7e6a1b94
                   helm.sh/chart=vouch-3.2.1
```