### PR TITLE
Add tpl function to ingress and config

### DIFF
--- a/charts/vouch/Chart.yaml
+++ b/charts/vouch/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 type: application
 appVersion: "0.39"
-version: 3.2.0
+version: 3.3.0
 name: vouch
 description: An SSO and OAuth login solution for nginx using the auth_request module.
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4

--- a/charts/vouch/templates/ingress.yaml
+++ b/charts/vouch/templates/ingress.yaml
@@ -27,14 +27,14 @@ spec:
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
+    - host: {{ tpl . $ | quote }}
       http:
         paths:
   {{- range $ingressPaths }}

--- a/charts/vouch/templates/secret.yaml
+++ b/charts/vouch/templates/secret.yaml
@@ -12,10 +12,10 @@ stringData:
   config.yaml: |
 {{- if .Values.config.vouch }}
     vouch:
-{{ toYaml .Values.config.vouch | indent 6 }}
+      {{- tpl (toYaml .Values.config.vouch) $ | nindent 6 }}
 {{- end }}
 {{- if .Values.config.oauth }}
     oauth:
-{{ toYaml .Values.config.oauth | indent 6 }}
+      {{- tpl (toYaml .Values.config.oauth) $ | nindent 6 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
this change add the tpl function to the config and ingress hosts.

This is useful, if this helm chart is part of an umbrella helm chart and the ingress hostname is defined as global value. 

The same goes for the configuration, since some properties like post url login and client id are also availible as global value.