### PR TITLE
Adds annotations on service

### DIFF
--- a/charts/vouch/templates/service.yaml
+++ b/charts/vouch/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "vouch.fullname" . }}
   labels:
 {{ include "vouch.labels" . | indent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -43,6 +43,7 @@ service:
   externalTrafficPolicy:
   type: ClusterIP
   port: 9090
+  annotations: {}
 
 probes:
   liveness:


### PR DESCRIPTION
This PR adds annotations on service.

This is useful if you want, for example, to create DNS records with external DNS:

```yaml
service:
  type: LoadBalancer
  port: 9090
  annotations:
    external-dns.alpha.kubernetes.io/hostname: <URL>
```