### PR TITLE
Native TLS

### DIFF
--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -75,6 +75,7 @@ spec:
             httpGet:
               path: /healthcheck
               port: http
+              scheme: {{ if .Values.nativeTLSSecretName }}HTTPS{{- else }}HTTP{{- end }}
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
@@ -86,6 +87,7 @@ spec:
             httpGet:
               path: /healthcheck
               port: http
+              scheme: {{ if .Values.nativeTLSSecretName }}HTTPS{{- else }}HTTP{{- end }}
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
@@ -97,6 +99,7 @@ spec:
             httpGet:
               path: /healthcheck
               port: http
+              scheme: {{ if .Values.nativeTLSSecretName }}HTTPS{{- else }}HTTP{{- end }}
             initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
@@ -108,6 +111,10 @@ spec:
             mountPath: /data
           - name: config
             mountPath: /config
+          {{- if .Values.nativeTLSSecretName }}
+          - name: tls
+            mountPath: /tls
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -116,6 +123,11 @@ spec:
           secretName: {{ if .Values.existingSecretName }}{{ .Values.existingSecretName }}{{- else }}{{ template "vouch.fullname" . }}{{- end }}
       - name: data
         emptyDir: {}
+      {{- if .Values.nativeTLSSecretName }}
+      - name: tls
+        secret:
+          secretName: {{ .Values.nativeTLSSecretName }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/vouch/templates/ingress.yaml
+++ b/charts/vouch/templates/ingress.yaml
@@ -14,8 +14,12 @@ metadata:
   name: {{ $fullName }}
   labels:
 {{ include "vouch.labels" . | indent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+  {{- if .Values.nativeTLSSecretName }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    ingress.kubernetes.io/protocol: https
+  {{- end }}
+  {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/vouch/templates/service.yaml
+++ b/charts/vouch/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "vouch.fullname" . }}
   labels:
 {{ include "vouch.labels" . | indent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -43,6 +43,7 @@ service:
   externalTrafficPolicy:
   type: ClusterIP
   port: 9090
+  annotations: {}
 
 probes:
   liveness:

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -102,11 +102,21 @@ podAnnotations: {}
 
 deploymentAnnotations: {}
 
+# If you want to have native TLS support on Vouch, use this Secret as TLS certificate
+# If you configured it this way, the ingress will have to communicate with Vouch using HTTPS
+# The annotations are already included for Nginx and Traefik ingress, and can be added as annotation to the ingress
+nativeTLSSecretName: ""
+
 # vouch config
 # bare minimum to get vouch running with google
 
 config:
   vouch:
+    # tls key must exists if nativeTLSSecretName is set for native TLS to work
+    # Certs are mounted in /tls and the file name must map the ones set in the Secret
+    # tls:
+    #   cert: /tls/tls.crt
+    #   key: /tls/tls.key
     port: 9090
     domains: []
     allowAllUsers: false


### PR DESCRIPTION
This PR adds the native TLS support from Vouch into this Helm chart.

It also contains modifications from https://github.com/vouch/helm-charts/pull/40 as I use them both, disregard these changes for this PR.