### PR TITLE
Add support for extra environment variables from secrets or configMaps

### DIFF
--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
+          {{- if .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml .Values.extraEnvFrom | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.config.vouch.port }}

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -131,3 +131,12 @@ existingSecretName: ""
 #   - name: HTTPS_PROXY
 #     value: "https://example.com"
 extraEnvVars: []
+
+# An array to add extra environment variables from a secret or configMap
+# Example:
+# extraEnvFrom:
+#   - secretRef:
+#       name: my-secret
+#   - configMapRef:
+#       name: my-configmap
+extraEnvFrom: []


### PR DESCRIPTION
Using `extraEnvFrom` simplifies the management of environment variables stored in secrets.

