### PR TITLE
Allow specifying envFrom values

### DIFF
--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
+          {{- if (not (empty .Values.extraEnvFrom)) }}
+          envFrom: {{ .Values.extraEnvFrom | toYaml | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.config.vouch.port }}

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -131,3 +131,10 @@ existingSecretName: ""
 #   - name: HTTPS_PROXY
 #     value: "https://example.com"
 extraEnvVars: []
+
+# An array to add extra environment variables
+# Example:
+# extraEnvFrom:
+#   - secretRef:
+#       name: vouch-secret-env
+extraEnvFrom: []


### PR DESCRIPTION
In the same vein as `extraEnvVars`, this allows folks to specify `envFrom:` values. This is helpful in setting environment variables from a `Secret`.